### PR TITLE
Bootstrap CP assets

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use Illuminate\Support\ServiceProvider;
+use Statamic\Statamic;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -13,7 +14,8 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        //
+        // Statamic::script('app', 'cp');
+        // Statamic::style('app', 'cp');
     }
 
     /**

--- a/resources/js/cp.js
+++ b/resources/js/cp.js
@@ -1,0 +1,6 @@
+// import ExampleFieldtype from './components/fieldtypes/ExampleFieldtype.vue';
+
+// Statamic.booting(() => {
+//     Statamic.$components.register('example-fieldtype', ExampleFieldtype);
+// });
+

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -13,3 +13,17 @@ let mix = require('laravel-mix');
 
 mix.js('resources/js/site.js', 'public/js')
    .sass('resources/sass/site.scss', 'public/css');
+
+
+/*
+ |--------------------------------------------------------------------------
+ | Statamic Control Panel Assets
+ |--------------------------------------------------------------------------
+ |
+ | Feel free to add your own JS or CSS to the Statamic Control Panel.
+ | https://statamic.dev/extending/control-panel#adding-css-and-js-assets
+ |
+ */
+
+// mix.js('resources/js/cp.js', 'public/vendor/app/js')
+//    .sass('resources/sass/cp.scss', 'public/vendor/app/css');


### PR DESCRIPTION
It may be fairly common to want to add your own CSS or JS to the Control Panel. (Project specific, not part of an addon.)

[There are a few steps for doing that in the docs](https://statamic.dev/extending/control-panel), but why not just have it ready to go.

It's commented out so nothing will happen out of the box, but uncomment them and away you go.
Or if the comments bother you, delete away!