### PR TITLE
gitignore the glide storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /public/storage
 /public/vendor/statamic
 /storage/*.key
+/storage/glide
 /vendor
 /.idea
 /.vscode


### PR DESCRIPTION
I think it would make sense to ignore auto-generated glide images as default for version control