### PR TITLE
Make example value uncommenting-friendly

### DIFF
--- a/config/statamic/oauth.php
+++ b/config/statamic/oauth.php
@@ -5,7 +5,7 @@ return [
     'enabled' => env('STATAMIC_OAUTH_ENABLED', false),
 
     'providers' => [
-        // github
+        // 'github',
     ],
 
     'routes' => [


### PR DESCRIPTION
Now this won't happen:

![Screen Shot 2020-08-02 at 00 58 02](https://user-images.githubusercontent.com/33033094/89111875-3b496680-d45b-11ea-971f-ca1008621f5d.png)
