### PR TITLE
Follow Laravels version convention

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "guzzlehttp/guzzle": "^6.3",
         "laravel/framework": "^7.0",
         "laravel/tinker": "^2.0",
-        "statamic/cms": "3.0.*"
+        "statamic/cms": "^3.0"
     },
     "require-dev": {
         "barryvdh/laravel-debugbar": "^3.2",


### PR DESCRIPTION
There is nothing wrong with the actual naming. 

My PR would streamline all used version requirements.