### PR TITLE
Remove link to Statamic Development Blog

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ In order to ensure that the Statamic community is welcoming to all and generally
 - [Statamic 3 Documentation][docs]
 - [Statamic 3 Core Package Repo][cms-repo]
 - [Statamic 3 Migrator](https://github.com/statamic/migrator)
-- [Statamic 3 Development Blog](https://v3.statamic.com)
 - [Statamic Discord][discord]
 
 [docs]: https://statamic.dev/


### PR DESCRIPTION
The v3 development blog now just redirects to statamic.com