### PR TITLE
Move script tag out of head

### DIFF
--- a/resources/views/layout.antlers.html
+++ b/resources/views/layout.antlers.html
@@ -6,11 +6,11 @@
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>{{ title ?? site:name }}</title>
         <link rel="stylesheet" href="{{ mix src='css/tailwind.css' }}">
-        <script src="{{ mix src='/js/site.js' }}"></script>
     </head>
     <body class="bg-gray-200 font-sans leading-normal text-grey-800">
         <div class="mx-auto px-2 h-screen flex items-center justify-center">
             {{ template_content }}
         </div>
+        <script src="{{ mix src='/js/site.js' }}"></script>
     </body>
 </html>


### PR DESCRIPTION
I had to move the script tag to the bottom of the HTML layout for my Vue component to render. Do you think this should be the default?