### PR TITLE
Update composer.json require-dev fzaninotto/faker to fakerphp/faker

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require-dev": {
         "barryvdh/laravel-debugbar": "^3.5",
         "facade/ignition": "^2.3.6",
-        "fzaninotto/faker": "^1.9.1",
+        "fakerphp/faker": "^1.11",
         "mockery/mockery": "^1.3.1",
         "nunomaduro/collision": "^5.0",
         "phpunit/phpunit": "^9.3"

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require-dev": {
         "barryvdh/laravel-debugbar": "^3.5",
         "facade/ignition": "^2.3.6",
-        "fakerphp/faker": "^1.11",
+        "fakerphp/faker": "^1.9.1",
         "mockery/mockery": "^1.3.1",
         "nunomaduro/collision": "^5.0",
         "phpunit/phpunit": "^9.3"


### PR DESCRIPTION
I'm kind of still new to composer and stuff. I always start new sites from statamic/statamic and everytime I updated via cli I got this message saying "Package fzaninotto/faker is abandoned, you should avoid using it. No replacement was suggested."

I wondered if it was an issue. I learned that it really isn't but then I wondered how I could get rid of that message. Turns out Taylor and others are maintaining a new version: https://github.com/fakerphp/faker and https://laravel-news.com/changes-coming-to-php-faker

So I updated the composer.json to use this new forked version and "abandoned notification" went away while updating. I think this will help rookies that worry way too much when they see stuff like this.