### PR TITLE
Set default table for logging failed jobs to `null`

### DIFF
--- a/config/queue.php
+++ b/config/queue.php
@@ -83,7 +83,7 @@ return [
     'failed' => [
         'driver' => env('QUEUE_FAILED_DRIVER', 'database'),
         'database' => env('DB_CONNECTION', 'mysql'),
-        'table' => 'failed_jobs',
+        'table' => null,
     ],
 
 ];


### PR DESCRIPTION
Statamic doesn't use a database by default, if you use queues but have no database, Laravel tries to put those failed jobs inside a database that doesn't exist.