### PR TITLE
Add *.antlers.php to tailwind config content array

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,7 @@
 module.exports = {
   content: [
     './resources/**/*.antlers.html',
+    './resources/**/*.antlers.php',
     './resources/**/*.blade.php',
     './resources/**/*.vue',
     './content/**/*.md'


### PR DESCRIPTION
The documentation mentions the ability of using .antlers.php instead of .antlers.html files to allow for raw php inside the template. When doing so, the file's content won't by scanned for tailwind classes anymore, potentially messing with the output. It has only happened to me once before, but I feel that anything used in the official docs should be considered here.