### PR TITLE
Update antlers.php

### DIFF
--- a/config/statamic/antlers.php
+++ b/config/statamic/antlers.php
@@ -16,6 +16,18 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Debugbar
+    |--------------------------------------------------------------------------
+    |
+    | Defaults to true. Set to false to disable antlers template profiling in
+    | the Laravel Debugbar package (when enabled).
+    |
+    */
+    
+    'debugbar' => env('STATAMIC_ANTLERS_DEBUGBAR', true),
+
+    /*
+    |--------------------------------------------------------------------------
     | Guarded Variables
     |--------------------------------------------------------------------------
     |


### PR DESCRIPTION
Disabling/enabling of the Antlers debugbar profiler i implemented in `profilerEnabled()` in `ViewServiceProvider` but missing from the config file