### PR TITLE
Add missing front-end translations

### DIFF
--- a/lang/en/validation.php
+++ b/lang/en/validation.php
@@ -1,0 +1,8 @@
+<?php
+
+return [
+
+    'unique_entry_value' => 'The :attribute has already been taken.',
+    'unique_user_value' => 'The :attribute has already been taken.',
+
+];


### PR DESCRIPTION
This pull request adds a `validation` translation file for two validation rules that get used in front-end forms. We previously included a `validation` translation file in the starter site, however it was removed as part of the Laravel 10 upgrade (#55).

Fixes statamic/cms#8640.