### PR TITLE
Use correct set_time_limit no limit value

### DIFF
--- a/config/statamic/system.php
+++ b/config/statamic/system.php
@@ -108,7 +108,7 @@ return [
     */
 
     'php_memory_limit' => '-1',
-    'php_max_execution_time' => '-1',
+    'php_max_execution_time' => '0',
     'ajax_timeout' => '600000',
     'pcre_backtrack_limit' => '-1',
 


### PR DESCRIPTION
As per https://github.com/statamic/cms/pull/9297, the default value should be `0` and not `-1`.