### PR TITLE
Add `static_cache` cache store

### DIFF
--- a/config/cache.php
+++ b/config/cache.php
@@ -92,6 +92,11 @@ return [
             'driver' => 'octane',
         ],
 
+        'static_cache' => [
+            'driver' => 'file',
+            'path' => storage_path('statamic/static-urls-cache'),
+        ],
+
     ],
 
     /*


### PR DESCRIPTION
As mentioned in https://github.com/statamic/cms/pull/9405

Add a `static_cache` cache store outside of the default cache, so it doesnt get affected by `cache:clear`.