### PR TITLE
[5.x] Update to Vite 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,15 +1,16 @@
 {
     "private": true,
+    "type": "module",
     "scripts": {
         "dev": "vite",
         "build": "vite build"
     },
     "devDependencies": {
-        "@tailwindcss/typography": "^0.5.9",
-        "autoprefixer": "^10.4.14",
-        "laravel-vite-plugin": "^0.7.2",
-        "postcss": "^8.4.23",
-        "tailwindcss": "^3.3.2",
-        "vite": "^4.0.0"
+        "@tailwindcss/typography": "^0.5.12",
+        "autoprefixer": "^10.4.19",
+        "laravel-vite-plugin": "^1.0.2",
+        "postcss": "^8.4.38",
+        "tailwindcss": "^3.4.3",
+        "vite": "^5.2.8"
     }
 }

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     plugins: {
         tailwindcss: {},
         autoprefixer: {},


### PR DESCRIPTION
This PR updates the npm dependencies to use Vite v5 and the Laravel Vite Plugin v1.

Furthermore it required changes to the build type, which is now `module` in the package.json, so that all js files are treated accordingly. That also has the implication of requiring `export default` in one file (this was already present in the other files).

The other changes are only dependency bumps to the latest version (I can also undo these changes if wanted.)

To test the Changes you only need to run:

```
npm i && npm run build
```