### PR TITLE
Use PHPUnit 11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "laravel/sail": "^1.26",
         "mockery/mockery": "^1.6",
         "nunomaduro/collision": "^8.0",
-        "phpunit/phpunit": "^10.5",
+        "phpunit/phpunit": "^11.0",
         "spatie/laravel-ignition": "^2.4"
     },
     "autoload": {


### PR DESCRIPTION
This pull request updates PHPUnit in `statamic/statamic` to v11. This mirrors the change from Laravel's `laravel/laravel` repository: laravel/laravel#6385

This should be merged after statamic/cms#10048 has been tagged.