### PR TITLE
Add `share_errors` config option to Static Caching config

### DIFF
--- a/config/statamic/static_caching.php
+++ b/config/statamic/static_caching.php
@@ -129,4 +129,19 @@ return [
 
     'warm_queue' => null,
 
+    /*
+    |--------------------------------------------------------------------------
+    | Shared Error Pages
+    |--------------------------------------------------------------------------
+    |
+    | You may choose to share the same statically generated error page across
+    | all errors. For example, the first time a 404 is encountered it will
+    | be generated and cached, and then served for all subsequent 404s.
+    |
+    | This is only supported for half measure.
+    |
+    */
+
+    'share_errors' => false,
+
 ];


### PR DESCRIPTION
Introduced in statamic/cms#10294.