### PR TITLE
Clarify repo differences

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,15 @@
 <p align="center"><img src="https://statamic.com/assets/branding/Statamic-Logo+Wordmark-Rad.svg" width="400" alt="Statamic Logo" /></p>
 
+# Statamic application
+
 ## About Statamic
 
 Statamic is the flat-first, Laravel + Git powered CMS designed for building beautiful, easy to manage websites.
 
-> **Note:** This repository contains the code for the Statamic application. To contribute to the core package, visit the [Statamic core package repository][cms-repo].
+> [!NOTE]
+> This repository contains the code for the Statamic application, for fresh installations using Statamic CLI. It has some differences to the base Statamic CMS as a result, to provide everything you need to get started from scratch.
+>
+> To install Statamic into an existing Laravel codebase, or contribute to the core package, visit the [Statamic core package repository][cms-repo].
 
 
 ## Learning Statamic

--- a/README.md
+++ b/README.md
@@ -1,15 +1,13 @@
 <p align="center"><img src="https://statamic.com/assets/branding/Statamic-Logo+Wordmark-Rad.svg" width="400" alt="Statamic Logo" /></p>
 
-# Statamic application
-
 ## About Statamic
 
 Statamic is the flat-first, Laravel + Git powered CMS designed for building beautiful, easy to manage websites.
 
 > [!NOTE]
-> This repository contains the code for the Statamic application, for fresh installations using Statamic CLI. It has some differences to the base Statamic CMS as a result, to provide everything you need to get started from scratch.
+> This repository contains the code for a fresh Statamic project that is installed via the Statamic CLI tool.
 >
-> To install Statamic into an existing Laravel codebase, or contribute to the core package, visit the [Statamic core package repository][cms-repo].
+> The code for the Statamic Composer package itself can be found at the [Statamic core package repository][cms-repo].
 
 
 ## Learning Statamic


### PR DESCRIPTION
Providing a clearer title and explanatory note at the top of the readme, to help new users understand the differences between the two Statamic repositories. Also moving the note to using the Github markdown styled alerts.