### PR TITLE
Specify custom asset_meta and asset_container_contents stores

### DIFF
--- a/config/cache.php
+++ b/config/cache.php
@@ -95,6 +95,15 @@ return [
             'path' => storage_path('statamic/static-urls-cache'),
         ],
 
+        'asset_container_contents' => [
+            'driver' => 'file',
+            'path' => storage_path('statamic/asset-container-contents'),
+        ],
+
+        'asset_meta' => [
+            'driver' => 'file',
+            'path' => storage_path('statamic/asset-meta'),
+        ],
     ],
 
     /*


### PR DESCRIPTION
This is maybe a bit opinionated, maybe not.

Currently asset meta and container contents get cleared by default when you run cache:clear. By default we should encourage people to use custom stores for these so they are only cleared as any when they need to be, not as part of a general cache clear.

I've opened a related PR https://github.com/statamic/cms/pull/11960 that lets you clear these using `please assets:clear-cache`