### PR TITLE
Add static caching directory to .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 /node_modules
 /public/build
 /public/hot
+/public/static
 /public/storage
 /public/vendor/statamic
 /storage/*.key


### PR DESCRIPTION
In our case, this was stopping git operations because there was unstaged changes in `public/static`. I don't think this should be git tracked, as it is generated by Statamic.