### PR TITLE
[6.x] Laravel Debugbar 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
         "statamic/cms": "^6.0"
     },
     "require-dev": {
-        "barryvdh/laravel-debugbar": "^3.8.1",
         "fakerphp/faker": "^1.23",
+        "fruitcake/laravel-debugbar": "^4.0",
         "laravel/pail": "^1.2.2",
         "laravel/pint": "^1.24",
         "laravel/sail": "^1.41",


### PR DESCRIPTION
This pull request updates to Laravel Debugbar 4, which was [released recently](https://fruitcake.nl/blog/laravel-debugbar-v4-release).

Relies on https://github.com/statamic/cms/pull/13781