### PR TITLE
Upgrade PHP requirement from 8.2 to 8.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "laravel"
     ],
     "require": {
-        "php": "^8.2",
+        "php": "^8.3",
         "laravel/framework": "^12.0",
         "laravel/tinker": "^2.10.1",
         "statamic/cms": "^6.0"


### PR DESCRIPTION
The upgrade guide for v6 states that the minimum requirement is PHP `8.3`.