### PR TITLE
Remove Laravel Ignition

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,7 @@
         "laravel/sail": "^1.41",
         "mockery/mockery": "^1.6",
         "nunomaduro/collision": "^8.6",
-        "phpunit/phpunit": "^12.5.12",
-        "spatie/laravel-ignition": "^2.9.1"
+        "phpunit/phpunit": "^12.5.12"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
         "laravel/sail": "^1.41",
         "mockery/mockery": "^1.6",
         "nunomaduro/collision": "^8.6",
-        "phpunit/phpunit": "^12.5.12"
+        "phpunit/phpunit": "^12.5.12",
+        "spatie/laravel-error-solutions": "^1.1"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This pull request removes `spatie/laravel-ignition` in favour of Laravel's default error page with `spatie/laravel-error-solutions`.

