### PR TITLE
Update static caching config

### DIFF
--- a/config/statamic/static_caching.php
+++ b/config/statamic/static_caching.php
@@ -100,7 +100,7 @@ return [
     |
     */
 
-    'ignore_query_strings' => false,
+    'ignore_query_strings' => true,
 
     'allowed_query_strings' => [
         //

--- a/config/statamic/static_caching.php
+++ b/config/statamic/static_caching.php
@@ -107,7 +107,7 @@ return [
     ],
 
     'disallowed_query_strings' => [
-        //
+        'fbclid', 'gclid', 'msclkid', 'utm_campaign', 'utm_content', 'utm_medium', 'utm_source', 'utm_term',
     ],
 
     /*


### PR DESCRIPTION
This pull request updates the default `static_caching.php` config, specifically the options around query strings:

- Query strings are now ignored by default.
    - Avoids issue where every query string combination would result in a separate cache key, potentially causing memory exhaustion issues. 
    - See https://github.com/statamic/cms/issues/13991.
- Added common marketing/tracking params to the `disallowed_query_strings` array.
    - The disallowed query params are only used by the half-measure cache driver, and when query strings are _not_ ignored.

Closes statamic/cms#13991